### PR TITLE
Failing test: extra space after 'if ... then return end'

### DIFF
--- a/test/function/__snapshots__/function.test.ts.snap
+++ b/test/function/__snapshots__/function.test.ts.snap
@@ -27,5 +27,11 @@ local test = function(arg, ...)
 end
 local test = function(...)
 end
+
+function foo()
+    if true then
+        return
+    end
+end
 "
 `;

--- a/test/function/functions.lua
+++ b/test/function/functions.lua
@@ -12,3 +12,5 @@ local test = function() end
 local test = function(arg) end
 local test = function(arg, ...) end
 local test = function(...) end
+
+function foo() if true then return end end


### PR DESCRIPTION
Hi, another bug ;-)

This time with a test attached, is this useful?