### PR TITLE
Failing test: trailing comments are missing indent level.

### DIFF
--- a/test/comments/__snapshots__/comments.test.ts.snap
+++ b/test/comments/__snapshots__/comments.test.ts.snap
@@ -120,3 +120,24 @@ until true -- Dangling End RepeatStatement
 -- trailing RepeatStatement
 "
 `;
+
+exports[`table.lua 1`] = `
+"-- Simple example
+a = {
+    b = true
+    -- Trailing comment should be indented
+}
+
+-- Deep example
+film = {
+    scene = {
+        object = {
+            name = \\"Swallow\\",
+            carrying = \\"Coconut\\",
+            origin = \\"Africa\\"
+            -- velocity = ??,
+        }
+    }
+}
+"
+`;

--- a/test/comments/table.lua
+++ b/test/comments/table.lua
@@ -1,0 +1,17 @@
+-- Simple example
+a = {
+    b = true
+    -- Trailing comment should be indented
+}
+
+-- Deep example
+film = {
+    scene = {
+        object = {
+            name = "Swallow",
+            carrying = "Coconut",
+            origin = "Africa"
+            -- velocity = ??,
+        }
+    }
+}


### PR DESCRIPTION
Challenge accepted :-)

A comment on the last line of a table or function seems to miss a
level of indentation.