### PR TITLE
Failing test: don't always convert quotemark.

### DIFF
--- a/test/quotes/__snapshots__/quotes.test.ts.snap
+++ b/test/quotes/__snapshots__/quotes.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`keep_quotemark.lua 1`] = `
+"-- Typical case with {quotemark: 'single' }
+print('this will be converted to single quotes')
+
+-- But keep original quotemark if the alternative quotemark is in the string.
+local filename = \\"It's Fred's friend's hamster's file\\"
+print(\\"'%s'\\", filename:gsub(\\"'\\", \\"'\\\\\\\\''\\"))
+"
+`;

--- a/test/quotes/keep_quotemark.lua
+++ b/test/quotes/keep_quotemark.lua
@@ -1,0 +1,6 @@
+-- Typical case with {quotemark: 'single' }
+print("this will be converted to single quotes")
+
+-- But keep original quotemark if the alternative quotemark is in the string.
+local filename = "It's Fred's friend's hamster's file"
+print("'%s'", filename:gsub("'","'\\''"))

--- a/test/quotes/quotes.test.ts
+++ b/test/quotes/quotes.test.ts
@@ -1,0 +1,3 @@
+import { runTest } from '../util';
+
+runTest(__dirname, { quotemark: 'single' });


### PR DESCRIPTION
If the alternative quotemark is used inside a string then don't
convert the expression because this reduces readability.