### PR TITLE
Compilation and indentation fixes

### DIFF
--- a/src/printer.ts
+++ b/src/printer.ts
@@ -213,9 +213,19 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
                 if (node.init.length) {
                     operator = ' =';
 
-                    right.push(
-                        join(concat([',', line]), path.map(print, 'init'))
-                    );
+                    if (node.init.length > 1) {
+                        right.push(
+                            indent(
+                                join(
+                                    concat([',', line]), path.map(print, 'init')
+                                )
+                            )
+                        );
+                    } else {
+                        right.push(
+                            join(concat([',', line]), path.map(print, 'init'))
+                        );
+                    }
                 }
 
                 // HACK: This definitely needs to be improved, as I'm sure TableConstructorExpression isn't the only

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -226,7 +226,11 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
                 // This results in the table's initial { character being moved to a separate line.
                 //
                 // There's probably a much better way of doing this, but it works for now.
-                const canBreakLine = node.init.some(n => n != null && n.type !== 'TableConstructorExpression');
+                const canBreakLine = node.init.some(n =>
+                    n != null &&
+                    n.type !== 'TableConstructorExpression' &&
+                    n.type !== 'FunctionDeclaration'
+                );
 
                 return group(
                     concat([

--- a/src/testPrinter.ts
+++ b/src/testPrinter.ts
@@ -4,5 +4,9 @@ import * as fs from 'fs';
 
 const file = fs.readFileSync('test/lua-5.3.4-tests/calls.lua');
 
-const formatted = luafmt.formatText(file.toString(), { lineWidth: 60, quotemark: 'single' });
+const formatted = luafmt.formatText(file.toString(), {
+    lineWidth: 60,
+    quotemark: 'single'
+});
+
 console.log(formatted);

--- a/src/util.ts
+++ b/src/util.ts
@@ -62,7 +62,7 @@ export interface SearchOptions {
     searchBackwards?: boolean;
 };
 
-export function skipOnce(text: string, idx: number, sequences: [string], searchOptions: SearchOptions = {}) {
+export function skipOnce(text: string, idx: number, sequences: string[], searchOptions: SearchOptions = {}) {
     let skipCount = 0;
     sequences.forEach(seq => {
         const searchText = searchOptions.searchBackwards
@@ -78,7 +78,7 @@ export function skipOnce(text: string, idx: number, sequences: [string], searchO
     return idx + (searchOptions.searchBackwards ? -skipCount : skipCount);
 }
 
-export function skipMany(text: string, idx: number, sequences: [string], searchOptions: SearchOptions = {}) {
+export function skipMany(text: string, idx: number, sequences: string[], searchOptions: SearchOptions = {}) {
     let oldIdx = null;
 
     while (oldIdx !== idx) {

--- a/test/function/__snapshots__/function.test.ts.snap
+++ b/test/function/__snapshots__/function.test.ts.snap
@@ -39,5 +39,14 @@ function foo()
 
     print(a)
 end
+
+local ok, err = pcall(foo)
+
+local ok,
+    err =
+    pcall(
+    function()
+    end
+)
 "
 `;

--- a/test/function/functions.lua
+++ b/test/function/functions.lua
@@ -20,3 +20,7 @@ function foo()
 
    print(a)
 end
+
+local ok, err = pcall(foo)
+
+local ok, err = pcall(function() end)

--- a/test/linewrap/__snapshots__/linewrap.test.ts.snap
+++ b/test/linewrap/__snapshots__/linewrap.test.ts.snap
@@ -21,5 +21,52 @@ local a,
     bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
     cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc =
     foo()
+
+local a, b, c, d, e, f = emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction(), emptyFunction()
+
+local a,
+    b,
+    c,
+    d,
+    e,
+    f =
+    emptyFunction(),
+    emptyFunction(
+        function()
+            return true
+        end
+    )
+
+local a,
+    b,
+    c,
+    d,
+    e,
+    f =
+    emptyFunction(
+    function()
+        return true
+    end
+)
+
+local function object()
+    local self = {}
+
+    function self:test()
+    end
+
+    self.test = function()
+    end
+
+    self.test = function()
+        -- Reaaaaally long comment, goes on forever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever
+    end
+
+    return self
+end
 "
 `;

--- a/test/linewrap/assignment.lua
+++ b/test/linewrap/assignment.lua
@@ -8,3 +8,29 @@ local a, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 print(a, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, c)
 
 local a, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc = foo()
+
+local a, b, c, d, e, f = emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction(), emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction(function() return true end)
+
+local a, b, c, d, e, f = emptyFunction(function() return true end)
+
+local function object()
+  local self = {}
+
+  function self:test()
+  end
+
+  self.test = function()
+  end
+
+  self.test = function()
+    -- Reaaaaally long comment, goes on forever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever
+  end
+
+  return self
+end

--- a/test/lua-5.3.4-tests/attrib.lua
+++ b/test/lua-5.3.4-tests/attrib.lua
@@ -464,33 +464,6 @@ end
 local a, b = foo()()
 assert(a == 3 and b == 14)
 
-
-local a, b, c, d, e, f = emptyFunction()
-
-local a, b, c, d, e, f = emptyFunction(), emptyFunction()
-
-local a, b, c, d, e, f = emptyFunction(), emptyFunction(), emptyFunction()
-
-local a, b, c, d, e, f = emptyFunction(), emptyFunction(function() return true end)
-
-local a, b, c, d, e, f = emptyFunction(function() return true end)
-
-local function object()
-  local self = {}
-
-  function self:test()
-  end
-
-  self.test = function()
-  end
-
-  self.test = function()
-    -- Reaaaaally long comment, goes on forever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever
-  end
-
-  return self
-end
-
 print('OK')
 
 return res

--- a/test/lua-5.3.4-tests/attrib.lua
+++ b/test/lua-5.3.4-tests/attrib.lua
@@ -398,7 +398,7 @@ a[1], f(a)[2], b, c = {['alo']=assert}, 10, a[1], a[f], 6, 10, 23, f(a), 2
 a[1].alo(a[2]==10 and b==10 and c==print)
 
 
--- test of large float/integer indices 
+-- test of large float/integer indices
 
 -- compute maximum integer where all bits fit in a float
 local maxint = math.maxinteger
@@ -463,6 +463,33 @@ end
 
 local a, b = foo()()
 assert(a == 3 and b == 14)
+
+
+local a, b, c, d, e, f = emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction(), emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction(function() return true end)
+
+local a, b, c, d, e, f = emptyFunction(function() return true end)
+
+local function object()
+  local self = {}
+
+  function self:test()
+  end
+
+  self.test = function()
+  end
+
+  self.test = function()
+    -- Reaaaaally long comment, goes on forever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever
+  end
+
+  return self
+end
 
 print('OK')
 

--- a/test/lua-5.3.4-tests/calls.lua
+++ b/test/lua-5.3.4-tests/calls.lua
@@ -31,7 +31,7 @@ do    -- test error in 'print' too...
   _ENV.tostring = function () return {} end
   local st, msg = pcall(print, 1)
   assert(st == false and string.find(msg, "must return a string"))
-  
+
   _ENV.tostring = tostring
 end
 
@@ -396,6 +396,16 @@ do
   end
   assert(assert(load(c))() == 10)
 end
+
+local a, b, c, d, e, f = emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction(), emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction(function() return true end)
+
+local a, b, c, d, e, f = emptyFunction(function() return true end)
 
 print('OK')
 return deep

--- a/test/lua-5.3.4-tests/calls.lua
+++ b/test/lua-5.3.4-tests/calls.lua
@@ -397,15 +397,6 @@ do
   assert(assert(load(c))() == 10)
 end
 
-local a, b, c, d, e, f = emptyFunction()
-
-local a, b, c, d, e, f = emptyFunction(), emptyFunction()
-
-local a, b, c, d, e, f = emptyFunction(), emptyFunction(), emptyFunction()
-
-local a, b, c, d, e, f = emptyFunction(), emptyFunction(function() return true end)
-
-local a, b, c, d, e, f = emptyFunction(function() return true end)
 
 print('OK')
 return deep


### PR DESCRIPTION
Master version was not compiling - wrong type on util.ts.

Fixes indentation issues when multiple assignments are on the right side:

```lua
-- before:
local a,
    b,
    c,
    d,
    e,
    f =
    emptyFunction(),
emptyFunction(
    function()
        return true
    end
)

-- after:
local a,
    b,
    c,
    d,
    e,
    f =
    emptyFunction(),
    emptyFunction(
        function()
            return true
        end
    )
```

Also fixes #18 