### PR TITLE
Add option for indenting multiple left-side assignments

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -10,7 +10,7 @@ export interface Options {
     lineWidth: number;
     indentCount: number;
     useTabs: boolean;
-    formatMultipleAssignments: boolean;
+    linebreakMultipleAssignments: boolean;
     quotemark: Quotemark;
     writeMode: WriteMode;
 }
@@ -22,7 +22,7 @@ export const defaultOptions: Options = {
     lineWidth: 120,
     indentCount: 4,
     useTabs: false,
-    formatMultipleAssignments: false,
+    linebreakMultipleAssignments: false,
     quotemark: 'double',
     writeMode: WriteMode.StdOut
 };

--- a/src/options.ts
+++ b/src/options.ts
@@ -10,6 +10,7 @@ export interface Options {
     lineWidth: number;
     indentCount: number;
     useTabs: boolean;
+    indentMultipleAssignments: boolean;
     quotemark: Quotemark;
     writeMode: WriteMode;
 }
@@ -21,6 +22,7 @@ export const defaultOptions: Options = {
     lineWidth: 120,
     indentCount: 4,
     useTabs: false,
+    indentMultipleAssignments: false,
     quotemark: 'double',
     writeMode: WriteMode.StdOut
 };

--- a/src/options.ts
+++ b/src/options.ts
@@ -10,7 +10,7 @@ export interface Options {
     lineWidth: number;
     indentCount: number;
     useTabs: boolean;
-    indentMultipleAssignments: boolean;
+    formatMultipleAssignments: boolean;
     quotemark: Quotemark;
     writeMode: WriteMode;
 }
@@ -22,7 +22,7 @@ export const defaultOptions: Options = {
     lineWidth: 120,
     indentCount: 4,
     useTabs: false,
-    indentMultipleAssignments: false,
+    formatMultipleAssignments: false,
     quotemark: 'double',
     writeMode: WriteMode.StdOut
 };

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -198,15 +198,14 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
                     left.push('local ');
                 }
 
-                const linelength = node.range['1'] - node.range['0'];
-                const shouldBreak = options.linebreakMultipleAssignments || linelength > options.lineWidth;
+                const shouldBreak = options.linebreakMultipleAssignments;
 
                 left.push(
                     indent(
                         join(
                             concat([
                                 ',',
-                                shouldBreak ? line : ' '
+                                shouldBreak ? hardline : line
                             ]),
                             path.map(print, 'variables')
                         )
@@ -250,7 +249,7 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
 
                 return group(
                     concat([
-                        concat(left),
+                        group(concat(left)),
                         group(
                             concat([
                                 operator,

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -213,9 +213,19 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
                 if (node.init.length) {
                     operator = ' =';
 
-                    right.push(
-                        join(concat([',', line]), path.map(print, 'init'))
-                    );
+                    if (node.init.length > 1) {
+                        right.push(
+                            indent(
+                                join(
+                                    concat([',', line]), path.map(print, 'init')
+                                )
+                            )
+                        );
+                    } else {
+                        right.push(
+                            join(concat([',', line]), path.map(print, 'init'))
+                        );
+                    }
                 }
 
                 // HACK: This definitely needs to be improved, as I'm sure TableConstructorExpression isn't the only

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -226,7 +226,11 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
                 // This results in the table's initial { character being moved to a separate line.
                 //
                 // There's probably a much better way of doing this, but it works for now.
-                const canBreakLine = node.init.some(n => n != null && n.type !== 'TableConstructorExpression');
+                const canBreakLine = node.init.some(n =>
+                    n != null &&
+                    n.type !== 'TableConstructorExpression' &&
+                    n.type !== 'FunctionDeclaration'
+                );
 
                 return group(
                     concat([

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -203,7 +203,7 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
                         join(
                             concat([
                                 ',',
-                                options.indentMultipleAssignments ? line : ' '
+                                options.formatMultipleAssignments ? line : ' '
                             ]),
                             path.map(print, 'variables')
                         )

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -201,7 +201,10 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
                 left.push(
                     indent(
                         join(
-                            concat([',', line]),
+                            concat([
+                                ',',
+                                options.indentMultipleAssignments ? line : ' '
+                            ]),
                             path.map(print, 'variables')
                         )
                     )

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -198,7 +198,7 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
                     left.push('local ');
                 }
 
-                const linelength = node.range["1"] - node.range["0"];
+                const linelength = node.range['1'] - node.range['0'];
                 const shouldBreak = options.linebreakMultipleAssignments || linelength > options.lineWidth;
 
                 left.push(

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -198,12 +198,15 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
                     left.push('local ');
                 }
 
+                const linelength = node.range["1"] - node.range["0"];
+                const shouldBreak = options.linebreakMultipleAssignments || linelength > options.lineWidth;
+
                 left.push(
                     indent(
                         join(
                             concat([
                                 ',',
-                                options.formatMultipleAssignments ? line : ' '
+                                shouldBreak ? line : ' '
                             ]),
                             path.map(print, 'variables')
                         )
@@ -253,7 +256,8 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
                                 operator,
                                 canBreakLine ? indent(line) : ' ',
                                 concat(right)
-                            ]))
+                            ])
+                        )
                     ])
                 );
             }

--- a/src/testPrinter.ts
+++ b/src/testPrinter.ts
@@ -4,5 +4,9 @@ import * as fs from 'fs';
 
 const file = fs.readFileSync('test/lua-5.3.4-tests/calls.lua');
 
-const formatted = luafmt.formatText(file.toString(), { lineWidth: 60, quotemark: 'single' });
+const formatted = luafmt.formatText(file.toString(), {
+    lineWidth: 60,
+    quotemark: 'single'
+});
+
 console.log(formatted);

--- a/src/util.ts
+++ b/src/util.ts
@@ -62,7 +62,7 @@ export interface SearchOptions {
     searchBackwards?: boolean;
 };
 
-export function skipOnce(text: string, idx: number, sequences: [string], searchOptions: SearchOptions = {}) {
+export function skipOnce(text: string, idx: number, sequences: string[], searchOptions: SearchOptions = {}) {
     let skipCount = 0;
     sequences.forEach(seq => {
         const searchText = searchOptions.searchBackwards
@@ -78,7 +78,7 @@ export function skipOnce(text: string, idx: number, sequences: [string], searchO
     return idx + (searchOptions.searchBackwards ? -skipCount : skipCount);
 }
 
-export function skipMany(text: string, idx: number, sequences: [string], searchOptions: SearchOptions = {}) {
+export function skipMany(text: string, idx: number, sequences: string[], searchOptions: SearchOptions = {}) {
     let oldIdx = null;
 
     while (oldIdx !== idx) {

--- a/test/function/__snapshots__/function.test.ts.snap
+++ b/test/function/__snapshots__/function.test.ts.snap
@@ -39,5 +39,14 @@ function foo()
 
     print(a)
 end
+
+local ok, err = pcall(foo)
+
+local ok,
+    err =
+    pcall(
+    function()
+    end
+)
 "
 `;

--- a/test/function/__snapshots__/function.test.ts.snap
+++ b/test/function/__snapshots__/function.test.ts.snap
@@ -42,8 +42,7 @@ end
 
 local ok, err = pcall(foo)
 
-local ok,
-    err =
+local ok, err =
     pcall(
     function()
     end

--- a/test/function/functions.lua
+++ b/test/function/functions.lua
@@ -20,3 +20,7 @@ function foo()
 
    print(a)
 end
+
+local ok, err = pcall(foo)
+
+local ok, err = pcall(function() end)

--- a/test/linewrap/__snapshots__/linewrap.test.ts.snap
+++ b/test/linewrap/__snapshots__/linewrap.test.ts.snap
@@ -28,12 +28,7 @@ local a, b, c, d, e, f = emptyFunction(), emptyFunction()
 
 local a, b, c, d, e, f = emptyFunction(), emptyFunction(), emptyFunction()
 
-local a,
-    b,
-    c,
-    d,
-    e,
-    f =
+local a, b, c, d, e, f =
     emptyFunction(),
     emptyFunction(
         function()

--- a/test/linewrap/__snapshots__/linewrap.test.ts.snap
+++ b/test/linewrap/__snapshots__/linewrap.test.ts.snap
@@ -21,5 +21,52 @@ local a,
     bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
     cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc =
     foo()
+
+local a, b, c, d, e, f = emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction(), emptyFunction()
+
+local a,
+    b,
+    c,
+    d,
+    e,
+    f =
+    emptyFunction(),
+    emptyFunction(
+        function()
+            return true
+        end
+    )
+
+local a,
+    b,
+    c,
+    d,
+    e,
+    f =
+    emptyFunction(
+    function()
+        return true
+    end
+)
+
+local function object()
+    local self = {}
+
+    function self:test()
+    end
+
+    self.test = function()
+    end
+
+    self.test = function()
+        -- Reaaaaally long comment, goes on forever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever
+    end
+
+    return self
+end
 "
 `;

--- a/test/linewrap/__snapshots__/linewrap.test.ts.snap
+++ b/test/linewrap/__snapshots__/linewrap.test.ts.snap
@@ -41,12 +41,7 @@ local a,
         end
     )
 
-local a,
-    b,
-    c,
-    d,
-    e,
-    f =
+local a, b, c, d, e, f =
     emptyFunction(
     function()
         return true

--- a/test/linewrap/assignment.lua
+++ b/test/linewrap/assignment.lua
@@ -8,3 +8,29 @@ local a, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 print(a, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, c)
 
 local a, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc = foo()
+
+local a, b, c, d, e, f = emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction(), emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction(function() return true end)
+
+local a, b, c, d, e, f = emptyFunction(function() return true end)
+
+local function object()
+  local self = {}
+
+  function self:test()
+  end
+
+  self.test = function()
+  end
+
+  self.test = function()
+    -- Reaaaaally long comment, goes on forever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever
+  end
+
+  return self
+end

--- a/test/lua-5.3.4-tests/attrib.lua
+++ b/test/lua-5.3.4-tests/attrib.lua
@@ -464,33 +464,6 @@ end
 local a, b = foo()()
 assert(a == 3 and b == 14)
 
-
-local a, b, c, d, e, f = emptyFunction()
-
-local a, b, c, d, e, f = emptyFunction(), emptyFunction()
-
-local a, b, c, d, e, f = emptyFunction(), emptyFunction(), emptyFunction()
-
-local a, b, c, d, e, f = emptyFunction(), emptyFunction(function() return true end)
-
-local a, b, c, d, e, f = emptyFunction(function() return true end)
-
-local function object()
-  local self = {}
-
-  function self:test()
-  end
-
-  self.test = function()
-  end
-
-  self.test = function()
-    -- Reaaaaally long comment, goes on forever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever
-  end
-
-  return self
-end
-
 print('OK')
 
 return res

--- a/test/lua-5.3.4-tests/attrib.lua
+++ b/test/lua-5.3.4-tests/attrib.lua
@@ -398,7 +398,7 @@ a[1], f(a)[2], b, c = {['alo']=assert}, 10, a[1], a[f], 6, 10, 23, f(a), 2
 a[1].alo(a[2]==10 and b==10 and c==print)
 
 
--- test of large float/integer indices 
+-- test of large float/integer indices
 
 -- compute maximum integer where all bits fit in a float
 local maxint = math.maxinteger
@@ -463,6 +463,33 @@ end
 
 local a, b = foo()()
 assert(a == 3 and b == 14)
+
+
+local a, b, c, d, e, f = emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction(), emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction(function() return true end)
+
+local a, b, c, d, e, f = emptyFunction(function() return true end)
+
+local function object()
+  local self = {}
+
+  function self:test()
+  end
+
+  self.test = function()
+  end
+
+  self.test = function()
+    -- Reaaaaally long comment, goes on forever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever and ever
+  end
+
+  return self
+end
 
 print('OK')
 

--- a/test/lua-5.3.4-tests/calls.lua
+++ b/test/lua-5.3.4-tests/calls.lua
@@ -31,7 +31,7 @@ do    -- test error in 'print' too...
   _ENV.tostring = function () return {} end
   local st, msg = pcall(print, 1)
   assert(st == false and string.find(msg, "must return a string"))
-  
+
   _ENV.tostring = tostring
 end
 
@@ -396,6 +396,16 @@ do
   end
   assert(assert(load(c))() == 10)
 end
+
+local a, b, c, d, e, f = emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction(), emptyFunction()
+
+local a, b, c, d, e, f = emptyFunction(), emptyFunction(function() return true end)
+
+local a, b, c, d, e, f = emptyFunction(function() return true end)
 
 print('OK')
 return deep

--- a/test/lua-5.3.4-tests/calls.lua
+++ b/test/lua-5.3.4-tests/calls.lua
@@ -397,15 +397,6 @@ do
   assert(assert(load(c))() == 10)
 end
 
-local a, b, c, d, e, f = emptyFunction()
-
-local a, b, c, d, e, f = emptyFunction(), emptyFunction()
-
-local a, b, c, d, e, f = emptyFunction(), emptyFunction(), emptyFunction()
-
-local a, b, c, d, e, f = emptyFunction(), emptyFunction(function() return true end)
-
-local a, b, c, d, e, f = emptyFunction(function() return true end)
 
 print('OK')
 return deep


### PR DESCRIPTION
Adds support for a new option `linebreakMultipleAssignments`, which when false avoids linebreaks when assigning to multiple variables at once.

```lua
-- before format
local ok, err = pcall(someFunction)

-- linebreakMultipleAssignments: true, same as current lua-fmt
local ok,
    err =
    pcall(someFunction)

-- linebreakMultipleAssignments: false
local ok, err = pcall(someFunction)
```

I've set it to `false` as the default, seeing as that is the most idiomatic Lua use as per Lua manuals, mailing list and popular Lua libraries.