### PR TITLE
[WIP] [Feedback] Inlining function call arguments

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -11,6 +11,7 @@ export interface Options {
     indentCount: number;
     useTabs: boolean;
     linebreakMultipleAssignments: boolean;
+    inlineFunctionCalls: boolean;
     quotemark: Quotemark;
     writeMode: WriteMode;
 }
@@ -23,6 +24,7 @@ export const defaultOptions: Options = {
     indentCount: 4,
     useTabs: false,
     linebreakMultipleAssignments: false,
+    inlineFunctionCalls: true,
     quotemark: 'double',
     writeMode: WriteMode.StdOut
 };

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -244,7 +244,8 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
                 const canBreakLine = node.init.some(n =>
                     n != null &&
                     n.type !== 'TableConstructorExpression' &&
-                    n.type !== 'FunctionDeclaration'
+                    n.type !== 'FunctionDeclaration' &&
+                    n.type !== 'CallExpression'
                 );
 
                 return group(

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -491,7 +491,6 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
             // fitting combination of argument layout. I.e: If all arguments but the last fit on the same line, and the
             // last argument is a table, it would be beneficial to break on the table, rather than breaking the entire
             // argument list.
-            // let shouldBreakExpression = hasNewLineInRange(options.sourceText, node.range[0], node.range[1]);
 
             const callExpressionSpacing = options.inlineFunctionCalls ?
             [

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -491,18 +491,27 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
             // fitting combination of argument layout. I.e: If all arguments but the last fit on the same line, and the
             // last argument is a table, it would be beneficial to break on the table, rather than breaking the entire
             // argument list.
+            // let shouldBreakExpression = hasNewLineInRange(options.sourceText, node.range[0], node.range[1]);
+
+            const callExpressionSpacing = options.inlineFunctionCalls ?
+            [
+                '(',
+                    concat([join(concat([',', ' ']), printedCallExpressionArgs)]),
+                ')'
+            ] :
+            [
+                '(',
+                indent(
+                    concat([softline, join(concat([',', line]), printedCallExpressionArgs)])
+                ),
+                softline,
+                ')'
+            ];
 
             return concat([
                 path.call(print, 'base'),
                 group(
-                    concat([
-                        '(',
-                        indent(
-                            concat([softline, join(concat([',', line]), printedCallExpressionArgs)])
-                        ),
-                        softline,
-                        ')'
-                    ]),
+                    concat(callExpressionSpacing),
                     printedCallExpressionArgs.some(willBreak)
                 )
             ]);

--- a/test/function/__snapshots__/function.test.ts.snap
+++ b/test/function/__snapshots__/function.test.ts.snap
@@ -42,9 +42,19 @@ end
 
 local ok, err = pcall(foo)
 
-local ok, err = pcall(
-    function()
-    end
-)
+local ok, err = pcall(function()
+end)
+
+local result = foo({1, 2, 3}, function(value)
+    return 1 % 2 == 0
+end)
+
+local result = foo({1, 2, 3}, \\"helloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo\\", \\"hi\\", true, nil, function(
+    value)
+    return 1 % 2 == 0
+end)
+
+local result = foo(function(value)
+end, {1, 2, 3}, \\"helloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo\\")
 "
 `;

--- a/test/function/__snapshots__/function.test.ts.snap
+++ b/test/function/__snapshots__/function.test.ts.snap
@@ -42,8 +42,7 @@ end
 
 local ok, err = pcall(foo)
 
-local ok, err =
-    pcall(
+local ok, err = pcall(
     function()
     end
 )

--- a/test/function/functions.lua
+++ b/test/function/functions.lua
@@ -25,6 +25,8 @@ local ok, err = pcall(foo)
 
 local ok, err = pcall(function() end)
 
-local result = test({1, 2, 3}, function(value) return 1 % 2 == 0 end)
+local result = foo({1, 2, 3}, function(value) return 1 % 2 == 0 end)
 
-local result = test({1, 2, 3}, "helloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo", 'hi', true, nil, function(value) return 1 % 2 == 0 end)
+local result = foo({1, 2, 3}, "helloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo", 'hi', true, nil, function(value) return 1 % 2 == 0 end)
+
+local result = foo(function(value) end, {1, 2, 3}, "helloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo")

--- a/test/function/functions.lua
+++ b/test/function/functions.lua
@@ -24,3 +24,7 @@ end
 local ok, err = pcall(foo)
 
 local ok, err = pcall(function() end)
+
+local result = test({1, 2, 3}, function(value) return 1 % 2 == 0 end)
+
+local result = test({1, 2, 3}, "helloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo", 'hi', true, nil, function(value) return 1 % 2 == 0 end)

--- a/test/linewrap/__snapshots__/linewrap.test.ts.snap
+++ b/test/linewrap/__snapshots__/linewrap.test.ts.snap
@@ -11,17 +11,11 @@ end
 local a,
     bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
     c = foo()
-print(
-    a,
-    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
-    c
-)
+print(a, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, c)
 
 local a,
     bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
-    cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc = foo(
-
-)
+    cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc = foo()
 
 local a, b, c, d, e, f = emptyFunction()
 
@@ -30,17 +24,13 @@ local a, b, c, d, e, f = emptyFunction(), emptyFunction()
 local a, b, c, d, e, f = emptyFunction(), emptyFunction(), emptyFunction()
 
 local a, b, c, d, e, f = emptyFunction(),
-    emptyFunction(
-        function()
-            return true
-        end
-    )
-
-local a, b, c, d, e, f = emptyFunction(
-    function()
+    emptyFunction(function()
         return true
-    end
-)
+    end)
+
+local a, b, c, d, e, f = emptyFunction(function()
+    return true
+end)
 
 local function object()
     local self = {}

--- a/test/linewrap/__snapshots__/linewrap.test.ts.snap
+++ b/test/linewrap/__snapshots__/linewrap.test.ts.snap
@@ -19,8 +19,9 @@ print(
 
 local a,
     bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
-    cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc =
-    foo()
+    cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc = foo(
+
+)
 
 local a, b, c, d, e, f = emptyFunction()
 
@@ -28,16 +29,14 @@ local a, b, c, d, e, f = emptyFunction(), emptyFunction()
 
 local a, b, c, d, e, f = emptyFunction(), emptyFunction(), emptyFunction()
 
-local a, b, c, d, e, f =
-    emptyFunction(),
+local a, b, c, d, e, f = emptyFunction(),
     emptyFunction(
         function()
             return true
         end
     )
 
-local a, b, c, d, e, f =
-    emptyFunction(
+local a, b, c, d, e, f = emptyFunction(
     function()
         return true
     end

--- a/test/linewrap/assignment.lua
+++ b/test/linewrap/assignment.lua
@@ -7,7 +7,7 @@ end
 local a, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, c = foo()
 print(a, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, c)
 
-local a, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc = foo()
+local a, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc = foo()
 
 local a, b, c, d, e, f = emptyFunction()
 


### PR DESCRIPTION
Hi there!

I wanted to be able to have inline anonymous function expressions, like so:
```lua
local ok, err = pcall(function()
    -- logic
end)
```

I've added a new configuration param `inlineFunctionCalls`, defaulting to `true` due to Lua's oficial documentation and common patterns (but can be persuaded to change it to default to `false`!) :-)

Examples:
```lua
-- input
local result = filter({1, 2, 3}, function(value) return 1 % 2 == 0 end)

-- output with inlineFunctionCalls: true
local result = filter({1, 2, 3}, function(value)
  return 1 % 2 == 0
end)

-- output with inlineFunctionCalls: false
local result = filter(
    {1, 2, 3},
    function(value)
        return 1 % 2 == 0
    end
)


-- desired (but not working yet) output with inlineFunctionCalls: true
local result = filter(
    {
        some_really_long_variable_name,
        some_even_larger_variable_name_I_mean_really_really_really_larger,
        this_feels_normal_in_comparison,
        tiny_1
    },
    my_func
)

-- desired (but not working yet) output with inlineFunctionCalls: true
local result = filter(
    {
        some_really_long_variable_name,
        some_even_larger_variable_name_I_mean_really_really_really_larger,
        this_feels_normal_in_comparison,
        tiny_1
    },
    function(value)
        return 1 % 2 == 0
    end
)

-- desired (but not working yet) output with inlineFunctionCalls: true
local result = test(
    {1, 2, 3},
    "helloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo",
    "hi",
    true,
    nil,
    function(value)
        return 1 % 2 == 0
    end
)

-- Cannot be formatted yet
local result = test(
    {1, 2, 3}
    -- a comment
)

-- results in
local result = test({1, 2, 3}-- a comment)
-- which breaks tests and is clearly not correct
```

I'm marking this PR as [WIP] because it is not ready to be merged yet. I'd love to have @trixnz feedback on it  :)
