### PR TITLE
Exit with code EX_DATAERR if --list-different and formatting needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Format a stream from `stdin`:
 - [ ] Add support for a `.luafmt` preferences file
 
 ## Testing
-`lua-fmt` uses [jest](https://facebook.github.io/jest/) for automated testing.
+`lua-fmt` uses [jest](https://facebook.github.io/jest/) for automated testing (`gulp test`).
 
 Among the user-created tests in the `test/` folder, a copy of the `lua-5.3.4` tests are executed after formatting to ensure the code remains syntactically correct after formatting. For this reason, please do not modify the `lua-5.3.4-tests` folder unless updating with new tests from the official Lua tests. To run these tests, `lua53` is expected to be available on the `PATH`.
 

--- a/bin/luafmt.ts
+++ b/bin/luafmt.ts
@@ -57,10 +57,12 @@ program
     .usage('[options] [file]')
     .option('--stdin', 'Read code from stdin')
     .option('-l, --line-width <width>', 'Maximum length of a line before it will be wrapped',
-    myParseInt, defaultOptions.lineWidth)
+        myParseInt, defaultOptions.lineWidth)
     .option('-i, --indent-count <count>', 'Number of characters to indent', myParseInt, defaultOptions.indentCount)
     .option('--use-tabs', 'Use tabs instead of spaces for indentation')
-    .option('-w, --write-mode <mode>', 'Mode for output', parseWriteMode, defaultOptions.writeMode);
+    .option('-w, --write-mode <mode>', 'Mode for output', parseWriteMode, defaultOptions.writeMode)
+    .option('-l, --list-different', 'Print if files are different from desired formatting.'
+        + 'If there are differences the script errors out, which is useful in a CI scenario.');
 
 program.parse(process.argv);
 
@@ -74,16 +76,30 @@ function printError(filename: string, err: Error) {
     }
 }
 
+
+function exitWithCorrectExitCode(filename: string, originalDocument: string, formattedDocument: string,
+    options: UserOptions) {
+    if (originalDocument !== formattedDocument && options.listDifferent) {
+        console.error(`Change needed when formatting ${filename}`)
+        process.exit(65);
+    }
+    process.exit(0);
+}
+
 const customOptions: UserOptions = {
     lineWidth: program.lineWidth,
     indentCount: program.indentCount,
     useTabs: program.useTabs,
-    writeMode: program.writeMode
+    writeMode: program.writeMode,
+    listDifferent: program.listDifferent
 };
 
 if (program.stdin) {
     getStdin().then(input => {
-        printFormattedDocument('<stdin>', input, formatText(input, customOptions), customOptions);
+        const formatted = formatText(input, customOptions);
+
+        printFormattedDocument('<stdin>', input, formatted, customOptions);
+        exitWithCorrectExitCode('<stdin>', input, formatted, customOptions);
     }).catch((err: Error) => {
         printError('<stdin>', err);
     });
@@ -107,6 +123,7 @@ if (program.stdin) {
         const formatted = formatText(input, customOptions);
 
         printFormattedDocument(filename, input, formatted, customOptions);
+        exitWithCorrectExitCode(filename, input, formatted, customOptions);
     } catch (err) {
         printError(filename, err);
     }

--- a/bin/luafmt.ts
+++ b/bin/luafmt.ts
@@ -79,7 +79,7 @@ function printError(filename: string, err: Error) {
 
 function exitWithCorrectExitCode(filename: string, originalDocument: string, formattedDocument: string,
     options: UserOptions) {
-    if (originalDocument !== formattedDocument && options.listDifferent) {
+    if (options.listDifferent && originalDocument !== formattedDocument) {
         console.error(`Change needed when formatting ${filename}`);
         process.exit(65);
     }

--- a/bin/luafmt.ts
+++ b/bin/luafmt.ts
@@ -80,7 +80,7 @@ function printError(filename: string, err: Error) {
 function exitWithCorrectExitCode(filename: string, originalDocument: string, formattedDocument: string,
     options: UserOptions) {
     if (originalDocument !== formattedDocument && options.listDifferent) {
-        console.error(`Change needed when formatting ${filename}`)
+        console.error(`Change needed when formatting ${filename}`);
         process.exit(65);
     }
     process.exit(0);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lua-fmt",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Format Lua code",
   "author": "trixnz",
   "homepage": "https://github.com/trixnz/lua-fmt",

--- a/src/options.ts
+++ b/src/options.ts
@@ -13,6 +13,7 @@ export interface Options {
     linebreakMultipleAssignments: boolean;
     quotemark: Quotemark;
     writeMode: WriteMode;
+    listDifferent: boolean;
 }
 
 export type UserOptions = Partial<Options>;
@@ -24,7 +25,8 @@ export const defaultOptions: Options = {
     useTabs: false,
     linebreakMultipleAssignments: false,
     quotemark: 'double',
-    writeMode: WriteMode.StdOut
+    writeMode: WriteMode.StdOut,
+    listDifferent: false
 };
 
 /** Returns the quotation mark to use from the provided option. */


### PR DESCRIPTION
![--list-different teaser](https://user-images.githubusercontent.com/2315367/47041479-2964d980-d189-11e8-95b9-343446424226.png)

# Why

In order to ensure `lua-fmt` has been run
We want to be able to run `lua-fmt --list-different` that exits with exit code above 0 if formatting was needed

# How

Exit code EX_DATAERR (65) selected after consulting [sysexits(3)](https://www.freebsd.org/cgi/man.cgi?query=sysexits&sektion=3)
Same flag and behavior as in [prettier](https://prettier.io/docs/en/cli.html#list-different).

# Tests on Windows 10

I had a failing test locally even before starting and was not able to resolve it.
- node --version  = v8.6.0
- npm --version  = 5.3.0
- OS = Windows 10           

```
 FAIL  test\lua-5.3.4.test.ts
  ● Lua 5.3.4 standalone tests › strings.lua can still pass tests after being formatted

    Error
      Error: lua53: stdin:214: assertion failed!
      stack traceback:
        [C]: in function 'assert'
        stdin:214: in main chunk
        [C]: in ?
```