### PR TITLE
Fix comment indentation in if statement without else

### DIFF
--- a/src/comments.ts
+++ b/src/comments.ts
@@ -1,10 +1,10 @@
-import { FastPath } from './fastPath';
-import { Doc, concat, indent, join, hardline, lineSuffix, breakParent } from './docBuilder';
-import { PrintFn } from './printer';
-import { locStart, locEnd, isNextLineEmpty, hasNewLine, isPreviousLineEmpty } from './util';
-import { Options } from './options';
+import * as luaparse from "luaparse";
 
-import * as luaparse from 'luaparse';
+import { breakParent, concat, Doc, hardline, indent, join, lineSuffix } from "./docBuilder";
+import { FastPath } from "./fastPath";
+import { Options } from "./options";
+import { PrintFn } from "./printer";
+import { hasNewLine, isNextLineEmpty, isPreviousLineEmpty, locEnd, locStart } from "./util";
 
 enum CommentType {
     Leading,
@@ -375,7 +375,7 @@ function handleIfStatementsWithNoBodyComments(precedingNode: luaparse.Node,
         return true;
     }
 
-    if (precedingNode && precedingNode.type === 'ElseClause') {
+    if (precedingNode && (precedingNode.type === 'ElseClause' || precedingNode.type == 'IfClause')) {
         addDanglingComment(precedingNode, comment);
         return true;
     }

--- a/src/docPrinter.ts
+++ b/src/docPrinter.ts
@@ -1,5 +1,5 @@
-import { Doc, LineSuffix } from './docBuilder';
-import { Options } from './options';
+import { Doc, LineSuffix } from "./docBuilder";
+import { Options } from "./options";
 
 enum Mode {
     Flat,
@@ -142,12 +142,10 @@ function printDocToStringWithState(doc: Doc, state: State) {
                 break;
 
             case 'indent':
-                {
-                    state.indentation++;
-                    printDocToStringWithState(doc.content, state);
-                    state.indentation--;
-                    break;
-                }
+                state.indentation++;
+                printDocToStringWithState(doc.content, state);
+                state.indentation--;
+                break;
 
             case 'lineSuffix':
                 state.lineSuffixes.push(doc);

--- a/test/comments/__snapshots__/comments.test.ts.snap
+++ b/test/comments/__snapshots__/comments.test.ts.snap
@@ -101,6 +101,10 @@ else -- dangling ElseClause
     -- body ElseClause
 end -- dangling End IfStatement
 -- trailing IfStatement
+
+if 1 then
+    -- body IfClause
+end
 "
 `;
 

--- a/test/comments/if.lua
+++ b/test/comments/if.lua
@@ -21,3 +21,7 @@ else -- dangling ElseClause
   -- body ElseClause
 end -- dangling End IfStatement
 -- trailing IfStatement
+
+if 1 then
+  -- body IfClause
+end


### PR DESCRIPTION
when format empty if block without else the comment is not indent properly

input:
```lua
if 1 then
  -- body IfClause
end
```
output before:
```lua
if 1 then
-- body IfClause
end
```

fix to:
```lua
if 1 then
    -- body IfClause
end
```

and remove bracket in switch case which not match other case in `src/docPrinter.ts`