### PR TITLE
Fix comment indentation in if statement without else

### DIFF
--- a/src/comments.ts
+++ b/src/comments.ts
@@ -375,7 +375,7 @@ function handleIfStatementsWithNoBodyComments(precedingNode: luaparse.Node,
         return true;
     }
 
-    if (precedingNode && precedingNode.type === 'ElseClause') {
+    if (precedingNode && (precedingNode.type === 'ElseClause' || precedingNode.type === 'IfClause')) {
         addDanglingComment(precedingNode, comment);
         return true;
     }

--- a/src/docPrinter.ts
+++ b/src/docPrinter.ts
@@ -142,12 +142,10 @@ function printDocToStringWithState(doc: Doc, state: State) {
                 break;
 
             case 'indent':
-                {
-                    state.indentation++;
-                    printDocToStringWithState(doc.content, state);
-                    state.indentation--;
-                    break;
-                }
+                state.indentation++;
+                printDocToStringWithState(doc.content, state);
+                state.indentation--;
+                break;
 
             case 'lineSuffix':
                 state.lineSuffixes.push(doc);

--- a/test/comments/__snapshots__/comments.test.ts.snap
+++ b/test/comments/__snapshots__/comments.test.ts.snap
@@ -101,6 +101,10 @@ else -- dangling ElseClause
     -- body ElseClause
 end -- dangling End IfStatement
 -- trailing IfStatement
+
+if 1 then
+    -- body IfClause
+end
 "
 `;
 

--- a/test/comments/if.lua
+++ b/test/comments/if.lua
@@ -21,3 +21,7 @@ else -- dangling ElseClause
   -- body ElseClause
 end -- dangling End IfStatement
 -- trailing IfStatement
+
+if 1 then
+  -- body IfClause
+end


### PR DESCRIPTION
*fixed from previous PR to not re format import
when format empty if block without else the comment is not indent properly

input:
```lua
if 1 then
  -- body IfClause
end
```
output before:
```lua
if 1 then
-- body IfClause
end
```

fix to:
```lua
if 1 then
    -- body IfClause
end
```

and remove bracket in switch case which not match other case in `src/docPrinter.ts`