### PR TITLE
Fix indentation of functions that receive tables

### DIFF
--- a/src/printer.ts
+++ b/src/printer.ts
@@ -244,7 +244,8 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
                 const canBreakLine = node.init.some(n =>
                     n != null &&
                     n.type !== 'TableConstructorExpression' &&
-                    n.type !== 'FunctionDeclaration'
+                    n.type !== 'FunctionDeclaration' &&
+                    n.type !== 'CallExpression'
                 );
 
                 return group(


### PR DESCRIPTION
This pull request fixes this issue that I reported in October: https://github.com/trixnz/lua-fmt/issues/35
Credits to Arpple for providing the code that fixed the issue in this comment: https://github.com/trixnz/lua-fmt/issues/35#issuecomment-430600174

Before:
```lua
instance =
    MyClass.new(
    {
        arguments
    }
)
```

After:
```lua
instance = MyClass.new(
    {
        arguments
    }
)
```