### PR TITLE
Add ability to format multiple files at once

### DIFF
--- a/bin/luafmt.ts
+++ b/bin/luafmt.ts
@@ -5,6 +5,7 @@ const pkg = require('../../package.json');
 import * as program from 'commander';
 import * as getStdin from 'get-stdin';
 import * as globby from 'globby';
+import chalk from 'chalk';
 import { promisify } from 'util';
 import { readFile, writeFile } from 'fs';
 
@@ -48,7 +49,15 @@ function printFormattedDocument(filename: string, originalDocument: string, form
                 throw new Error('Write mode \'replace\' is incompatible with --stdin');
             }
 
-            return writeFileAsync(filename, formattedDocument);
+            if (originalDocument === formattedDocument) {
+              process.stdout.write(`${chalk.gray(filename)}\n`);
+              return Promise.resolve();
+            }
+
+            return writeFileAsync(filename, formattedDocument)
+              .then(() => {
+                process.stdout.write(`${chalk.white(filename)}\n`);
+              });
 
         default:
             throw new Error(`Invalid write mode \'${options.writeMode}\'`);

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@types/commander": "^2.3.31",
     "@types/diff": "^3.2.0",
     "@types/get-stdin": "^5.0.0",
+    "chalk": "^2.4.2",
     "commander": "^2.9.0",
     "diff": "^3.3.0",
     "get-stdin": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "jest": {
     "transform": {
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      ".(ts|tsx)": "ts-jest"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [
@@ -53,22 +53,22 @@
     ]
   },
   "devDependencies": {
-    "@types/jest": "^19.2.2",
-    "@types/node": "^7.0.8",
+    "@types/jest": "^24.0.18",
+    "@types/node": "^12.7.4",
     "gulp": "^3.9.1",
     "gulp-bump": "^2.7.0",
     "gulp-git": "^2.1.0",
     "gulp-shell": "^0.6.1",
     "gulp-tag-version": "^1.3.0",
-    "gulp-tslint": "^7.1.0",
-    "jest": "^19.0.2",
+    "gulp-tslint": "^8.1.4",
+    "jest": "^24.9.0",
     "npm-watch": "^0.1.8",
     "raw-loader": "^0.5.1",
     "source-map-support": "^0.4.11",
-    "ts-jest": "^19.0.6",
-    "ts-loader": "^2.0.1",
-    "tslint": "^4.5.1",
-    "typescript": "^2.2.1",
+    "ts-jest": "^24.0.2",
+    "ts-loader": "^6.0.4",
+    "tslint": "^5.19.0",
+    "typescript": "^3.6.2",
     "uglify-js": "mishoo/UglifyJS2#harmony",
     "uglifyjs-webpack-plugin": "^0.3.0",
     "webpack": "^2.2.1",
@@ -81,6 +81,7 @@
     "commander": "^2.9.0",
     "diff": "^3.3.0",
     "get-stdin": "^5.0.1",
+    "globby": "^10.0.1",
     "luaparse": "oxyc/luaparse#ac42a00ebf4020b8c9d3219e4b0f84bf7ce6e802"
   }
 }

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -29,7 +29,7 @@ function getChildrenOfNode(node: luaparse.Node): luaparse.Node[] {
 
             children.splice(idx + 1, 0, n);
         }
-    };
+    }
 
     for (const key of keys) {
         const val = node[key];

--- a/src/docPrinter.ts
+++ b/src/docPrinter.ts
@@ -4,7 +4,7 @@ import { Options } from './options';
 enum Mode {
     Flat,
     Break
-};
+}
 
 interface State {
     options: Options;
@@ -141,13 +141,12 @@ function printDocToStringWithState(doc: Doc, state: State) {
                 state.currentLineLength = renderedIndentation.length;
                 break;
 
-            case 'indent':
-                {
-                    state.indentation++;
-                    printDocToStringWithState(doc.content, state);
-                    state.indentation--;
-                    break;
-                }
+            case 'indent': {
+                state.indentation++;
+                printDocToStringWithState(doc.content, state);
+                state.indentation--;
+                break;
+            }
 
             case 'lineSuffix':
                 state.lineSuffixes.push(doc);

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -190,76 +190,75 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
             return concat(parts);
 
         case 'LocalStatement':
-        case 'AssignmentStatement':
-            {
-                const left = [];
+        case 'AssignmentStatement': {
+            const left = [];
 
-                if (node.type === 'LocalStatement') {
-                    left.push('local ');
-                }
-
-                const shouldBreak = options.linebreakMultipleAssignments;
-
-                left.push(
-                    indent(
-                        join(
-                            concat([
-                                ',',
-                                shouldBreak ? hardline : line
-                            ]),
-                            path.map(print, 'variables')
-                        )
-                    )
-                );
-
-                let operator = '';
-
-                const right = [];
-                if (node.init.length) {
-                    operator = ' =';
-
-                    if (node.init.length > 1) {
-                        right.push(
-                            indent(
-                                join(
-                                    concat([',', line]), path.map(print, 'init')
-                                )
-                            )
-                        );
-                    } else {
-                        right.push(
-                            join(concat([',', line]), path.map(print, 'init'))
-                        );
-                    }
-                }
-
-                // HACK: This definitely needs to be improved, as I'm sure TableConstructorExpression isn't the only
-                // candidate that falls under this critera.
-                //
-                // Due to the nature of how groups break, if the TableConstructorExpression contains a newline (and
-                // thusly breaks), the break will propagate all the way up to the group on the left of the assignment.
-                // This results in the table's initial { character being moved to a separate line.
-                //
-                // There's probably a much better way of doing this, but it works for now.
-                const canBreakLine = node.init.some(n =>
-                    n != null &&
-                    n.type !== 'TableConstructorExpression' &&
-                    n.type !== 'FunctionDeclaration'
-                );
-
-                return group(
-                    concat([
-                        group(concat(left)),
-                        group(
-                            concat([
-                                operator,
-                                canBreakLine ? indent(line) : ' ',
-                                concat(right)
-                            ])
-                        )
-                    ])
-                );
+            if (node.type === 'LocalStatement') {
+                left.push('local ');
             }
+
+            const shouldBreak = options.linebreakMultipleAssignments;
+
+            left.push(
+                indent(
+                    join(
+                        concat([
+                            ',',
+                            shouldBreak ? hardline : line
+                        ]),
+                        path.map(print, 'variables')
+                    )
+                )
+            );
+
+            let operator = '';
+
+            const right = [];
+            if (node.init.length) {
+                operator = ' =';
+
+                if (node.init.length > 1) {
+                    right.push(
+                        indent(
+                            join(
+                                concat([',', line]), path.map(print, 'init')
+                            )
+                        )
+                    );
+                } else {
+                    right.push(
+                        join(concat([',', line]), path.map(print, 'init'))
+                    );
+                }
+            }
+
+            // HACK: This definitely needs to be improved, as I'm sure TableConstructorExpression isn't the only
+            // candidate that falls under this critera.
+            //
+            // Due to the nature of how groups break, if the TableConstructorExpression contains a newline (and
+            // thusly breaks), the break will propagate all the way up to the group on the left of the assignment.
+            // This results in the table's initial { character being moved to a separate line.
+            //
+            // There's probably a much better way of doing this, but it works for now.
+            const canBreakLine = node.init.some(n =>
+                n != null &&
+                n.type !== 'TableConstructorExpression' &&
+                n.type !== 'FunctionDeclaration'
+            );
+
+            return group(
+                concat([
+                    group(concat(left)),
+                    group(
+                        concat([
+                            operator,
+                            canBreakLine ? indent(line) : ' ',
+                            concat(right)
+                        ])
+                    )
+                ])
+            );
+        }
 
         case 'CallStatement':
             return path.call(print, 'expression');
@@ -431,7 +430,7 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
 
         // Expressions
         case 'BinaryExpression':
-        case 'LogicalExpression':
+        case 'LogicalExpression': {
             const parent = path.getParent() as luaparse.Node;
             const shouldGroup = parent.type !== node.type &&
                 node.left.type !== node.type &&
@@ -451,6 +450,7 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
                     ]))
                 ])
             );
+        }
 
         case 'UnaryExpression':
             parts.push(node.operator);
@@ -520,7 +520,7 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
 
             return concat(parts);
 
-        case 'TableConstructorExpression':
+        case 'TableConstructorExpression': {
             if (node.fields.length === 0) {
                 return '{}';
             }
@@ -549,6 +549,7 @@ function printNodeNoParens(path: FastPath, options: Options, print: PrintFn) {
                 ]),
                 shouldBreak
             );
+        }
 
         case 'TableKeyString':
             return concat([

--- a/src/util.ts
+++ b/src/util.ts
@@ -60,7 +60,7 @@ export function isNode(value: any) {
 
 export interface SearchOptions {
     searchBackwards?: boolean;
-};
+}
 
 export function skipOnce(text: string, idx: number, sequences: string[], searchOptions: SearchOptions = {}) {
     let skipCount = 0;

--- a/test/comments/__snapshots__/comments.test.ts.snap
+++ b/test/comments/__snapshots__/comments.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`do.lua 1`] = `
+exports[`comments: do.lua 1`] = `
 "do -- Dangling Begin DoStatement
 end -- Dangling End DoStatement
 
@@ -17,7 +17,7 @@ end -- Dangling End DoStatement
 "
 `;
 
-exports[`for.lua 1`] = `
+exports[`comments: for.lua 1`] = `
 "for i = 0, 1, 2 do -- dangling Begin ForNumericStatement
 end -- Dangling End ForNumericStatement
 
@@ -48,7 +48,7 @@ end -- Dangling End ForNumericStatement
 "
 `;
 
-exports[`function.lua 1`] = `
+exports[`comments: function.lua 1`] = `
 "function test() -- dangling Begin FunctionDeclaration
 end -- dangling FunctionDeclaration
 
@@ -77,7 +77,7 @@ end -- dangling FunctionDeclaration
 "
 `;
 
-exports[`if.lua 1`] = `
+exports[`comments: if.lua 1`] = `
 "if 1 then -- dangling IfClause
 elseif 1 then -- dangling ElseIfClause
 else -- dangling ElseClause
@@ -104,7 +104,7 @@ end -- dangling End IfStatement
 "
 `;
 
-exports[`repeat.lua 1`] = `
+exports[`comments: repeat.lua 1`] = `
 "repeat -- Dangling Begin RepeatStatement
 until true -- Dangling End RepeatStatement
 
@@ -121,7 +121,7 @@ until true -- Dangling End RepeatStatement
 "
 `;
 
-exports[`table.lua 1`] = `
+exports[`comments: table.lua 1`] = `
 "-- Simple example
 a = {
     b = true

--- a/test/function/__snapshots__/function.test.ts.snap
+++ b/test/function/__snapshots__/function.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`functions.lua 1`] = `
+exports[`function: functions.lua 1`] = `
 "function test()
 end
 function test(arg)

--- a/test/linewrap/__snapshots__/linewrap.test.ts.snap
+++ b/test/linewrap/__snapshots__/linewrap.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`assignment.lua 1`] = `
+exports[`linewrap: assignment.lua 1`] = `
 "bbbbbbbbbbbbbbbbbbbbbbb = true
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
     bbbbbbbbbbbbbbbbbbbbbbb

--- a/test/quotes/__snapshots__/quotes.test.ts.snap
+++ b/test/quotes/__snapshots__/quotes.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`keep_quotemark.lua 1`] = `
+exports[`quotes: keep_quotemark.lua 1`] = `
 "-- Typical case with {quotemark: 'single' }
 print('this will be converted to single quotes')
 

--- a/test/shebang/__snapshots__/shebang.test.ts.snap
+++ b/test/shebang/__snapshots__/shebang.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`keep_shebang.lua 1`] = `
+exports[`shebang: keep_shebang.lua 1`] = `
 "#!/usr/bin/env lua
 
 print(\\"Hello, World\\")

--- a/tslint.json
+++ b/tslint.json
@@ -60,7 +60,6 @@
         "no-trailing-whitespace": true,
         "no-unsafe-finally": true,
         "no-unused-expression": true,
-        "no-unused-new": true,
         "no-var-keyword": true,
 
         "object-literal-key-quotes": [


### PR DESCRIPTION
Uses [globby](https://github.com/sindresorhus/globby) to list files matched by a pattern, pretty much like `prettier`'s CLI does.

It supports passing multiple filenames/patterns. I'm using the same globby options as prettier (include dotfiles).

It does not ignore any files, but it should be desirable to implement after this initial work.

Also, I didn't modify the output for `stdout` and `diff` write modes, so they will simply print the output sequentially for all matched files, which can be useless (in `stdout` mode for multiple files) or too cluttered (in `diff` mode).

Finally, I took the liberty to upgrade some dependencies (notably: typescript, tslint, jest), since they weren't working properly with newer node versions (10.x). I hope that isn't too intrusive.